### PR TITLE
Decorate ExtraFlexPlugin after composer instance is done being initialized

### DIFF
--- a/src/Composer/ExtraFlexPlugin.php
+++ b/src/Composer/ExtraFlexPlugin.php
@@ -15,6 +15,7 @@ use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\Capable;
+use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PluginInterface;
 use Symfony\Flex\Configurator;
 use Symfony\Flex\Downloader;
@@ -202,15 +203,13 @@ class ExtraFlexPlugin implements Capable, PluginInterface, EventSubscriberInterf
     public static function getSubscribedEvents()
     {
         return [
-            PackageEvents::PRE_PACKAGE_INSTALL => [
+            PluginEvents::INIT => [
                 ['decorate', 42],
             ],
             PackageEvents::POST_PACKAGE_INSTALL => [
-                ['decorate', 42],
                 ['update'],
             ],
             PackageEvents::PRE_PACKAGE_UNINSTALL => [
-                ['decorate', 42],
                 ['update'],
             ],
             'pre-flex-configurator-install' => 'configuratorLog',


### PR DESCRIPTION
This patch fixes #1 for me.

The problem was that the `ExtraFlexPlugin::decorate` method was not invoked when using the apply command. So, the `configurator` was not set which in turn caused an invalid method call on `null`.

I thought it would make sense to always decorate the plugin, so I moved this step to the very beginning, no matter if it is really required or not. I wasn't sure if I should move this to the `INIT` event or just add a subscriber for the `COMMAND` event, which would also work. But I thought it wouldn't hurt to always decorate the plugin. :wink: 