### PR TITLE
Decorate plugin additionally on specific events

### DIFF
--- a/src/Composer/ExtraFlexPlugin.php
+++ b/src/Composer/ExtraFlexPlugin.php
@@ -206,10 +206,15 @@ class ExtraFlexPlugin implements Capable, PluginInterface, EventSubscriberInterf
             PluginEvents::INIT => [
                 ['decorate', 42],
             ],
+            PackageEvents::PRE_PACKAGE_INSTALL => [
+                ['decorate', 42],
+            ],
             PackageEvents::POST_PACKAGE_INSTALL => [
+                ['decorate', 42],
                 ['update'],
             ],
             PackageEvents::PRE_PACKAGE_UNINSTALL => [
+                ['decorate', 42],
                 ['update'],
             ],
             'pre-flex-configurator-install' => 'configuratorLog',


### PR DESCRIPTION
I'm sorry, the previous pull request introduced an error on the first time this plugin will be installed.

By decorating the plugin on composer init only, it won't be decorated the very first time when it is installed, explicitly or by dependency. Makes sense if you think about it. The very first time, the plugin is not yet installed, so it had no chance to register as a subscriber on the init event. :wink: 
I thought I tested this with the changes of #2 but obviously not. :-/

So, I readded the decoration for the install/uninstall events which fixed the issue for me. This time I tested a clean installation.

I also tried to use `PluginEvents::COMMAND` but currently there seems to be changes in the composer api, so `PluginEvents::COMMAND` is not fired but instead `PluginEvents::PRE_COMMAND_RUN` is fired (for me).

I think in terms of backwards compatibility it may be safer to stick with the `INIT` event, otherwise it might be required to update the composer api. I don't know what other consequences might be, so I think `INIT` is still a good candidate for decorating the plugin.

Sorry for introducing this error with my last pull request. :-/